### PR TITLE
Add LC Resonant Frequency calculator

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,6 +38,7 @@ import ElectricalPlugReference from "./calculators/ElectricalPlugReference";
 import ResistorColorCodeCalculator from "./calculators/ResistorColorCodeCalculator";
 import SMDResistorCodeCalculator from "./calculators/SMDResistorCodeCalculator";
 import SMDCapacitorCodeCalculator from "./calculators/SMDCapacitorCodeCalculator";
+import LCResonantFrequencyCalculator from "./calculators/LCResonantFrequencyCalculator";
 
 function App() {
   const [tab, setTab] = useState("all");
@@ -89,6 +90,7 @@ function App() {
           <Route path="/time-constant-calculator" element={<TimeConstantCalculator />} />
           <Route path="/trace-impedance-calculator" element={<TraceImpedanceCalculator />} />
           <Route path="/voltage-divider-calculator" element={<VoltageDividerCalculator />} />
+          <Route path="/lc-resonant-frequency-calculator" element={<LCResonantFrequencyCalculator />} />
 
           {/* Identification */}
           <Route path="/electrical-plug-reference" element={<ElectricalPlugReference />} />

--- a/src/calculators/LCResonantFrequencyCalculator.js
+++ b/src/calculators/LCResonantFrequencyCalculator.js
@@ -1,0 +1,44 @@
+import React, { useState } from "react";
+
+function LCResonantFrequencyCalculator() {
+  const [inductance, setInductance] = useState("");
+  const [capacitance, setCapacitance] = useState("");
+  const [frequency, setFrequency] = useState(null);
+
+  const calculate = () => {
+    const L = parseFloat(inductance);
+    const C = parseFloat(capacitance);
+    if (L > 0 && C > 0) {
+      const f = 1 / (2 * Math.PI * Math.sqrt(L * 1e-6 * C * 1e-12));
+      setFrequency(f.toFixed(4));
+    } else {
+      setFrequency(null);
+    }
+  };
+
+  return (
+    <div>
+      <h2>LC Resonant Frequency Calculator</h2>
+      <input
+        type="number"
+        placeholder="Inductance (µH)"
+        value={inductance}
+        onChange={e => setInductance(e.target.value)}
+      />
+      <input
+        type="number"
+        placeholder="Capacitance (pF)"
+        value={capacitance}
+        onChange={e => setCapacitance(e.target.value)}
+      />
+      <button onClick={calculate}>Calculate</button>
+      {frequency !== null && (
+        <div style={{ marginTop: 16 }}>
+          Resonant Frequency: <b>{frequency} MHz</b>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default LCResonantFrequencyCalculator;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -201,6 +201,13 @@ const calculators = [
     category: "calculation"
   },
   {
+    title: "LC Resonant Frequency Calculator",
+    description: "Find the resonant frequency for an LC circuit.",
+    to: "/lc-resonant-frequency-calculator",
+    icon: "🧮",
+    category: "calculation"
+  },
+  {
     title: "555 Timer Calculator",
     description: "Calculate frequency/duty cycle for 555 circuits.",
     to: "/timer-555-calculator",


### PR DESCRIPTION
## Summary
- add a new calculator component for LC resonant frequency
- register the calculator route in `App.js`
- list the calculator on the home page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a3d8f332083309f6a28dd2e7ca6f6